### PR TITLE
[Bug][#31]Crash after screen rotation

### DIFF
--- a/app/src/main/java/com/jim/sharetocomputer/MainFragment.kt
+++ b/app/src/main/java/com/jim/sharetocomputer/MainFragment.kt
@@ -32,14 +32,13 @@ import com.jim.sharetocomputer.logging.MyLog
 import com.journeyapps.barcodescanner.BarcodeEncoder
 import org.koin.android.ext.android.inject
 import org.koin.android.viewmodel.ext.android.viewModel
-import org.koin.core.parameter.parametersOf
 import org.koin.core.qualifier.named
 
 
 class MainFragment : Fragment() {
 
     private val port by inject<Int>(named("PORT"))
-    private val mainViewModel: MainViewModel by viewModel(parameters = { parametersOf(activity) })
+    private val mainViewModel: MainViewModel by viewModel()
     private var qrCodeBitmap: Bitmap? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -48,7 +47,8 @@ class MainFragment : Fragment() {
         val binding = FragmentMainBinding.inflate(inflater, container, false)
         binding.lifecycleOwner = this
         binding.viewModel = mainViewModel
-        mainViewModel.qrcode.value = BitmapDrawable(activity?.resources, qrCodeBitmap)
+        mainViewModel.qrcode.value = BitmapDrawable(activity!!.resources, qrCodeBitmap)
+        mainViewModel.context = activity!!
 
         val request = arguments?.get(ARGS_REQUEST) as ShareRequest?
         mainViewModel.setRequest(request)

--- a/app/src/main/java/com/jim/sharetocomputer/MainViewModel.kt
+++ b/app/src/main/java/com/jim/sharetocomputer/MainViewModel.kt
@@ -18,11 +18,12 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 
 
-class MainViewModel(private val context: FragmentActivity, private val port: Int) : ViewModel() {
+class MainViewModel(private val port: Int) : ViewModel() {
 
     private var request: ShareRequest? = null
     val ip = MutableLiveData<String>().apply { value = "unknown" }
     var qrcode = MutableLiveData<Drawable>()
+    lateinit var context: FragmentActivity
 
     fun selectFile() {
         MyLog.i("Select File")

--- a/app/src/main/java/com/jim/sharetocomputer/Modules.kt
+++ b/app/src/main/java/com/jim/sharetocomputer/Modules.kt
@@ -16,7 +16,6 @@
 */
 package com.jim.sharetocomputer
 
-import androidx.fragment.app.FragmentActivity
 import com.jim.sharetocomputer.webserver.WebServerMultipleFiles
 import com.jim.sharetocomputer.webserver.WebServerSingleFile
 import com.jim.sharetocomputer.webserver.WebServerText
@@ -30,7 +29,7 @@ val applicationModule = module {
     factory { WebServerText(get(named(Module.PORT))) }
     factory { WebServerSingleFile(get(), get(named(Module.PORT))) }
     factory { WebServerMultipleFiles(get(), get(named(Module.PORT))) }
-    viewModel { (activity: FragmentActivity) -> MainViewModel(activity, get(named(Module.PORT))) }
+    viewModel { MainViewModel(get(named(Module.PORT))) }
 }
 
 object Module {


### PR DESCRIPTION
Cause: singleton view model hold the previous (destroyed) activity instance
Solution: move activity reference from constructor parameter to class variable that will be set through setter