### PR TITLE
[Build] Fix random android test fail 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,17 +37,21 @@ install:
   - echo no | avdmanager create avd --force -n test -k "system-images;android-$API;$EMU_FLAVOR;$ABI" -c 10M
   - emulator -verbose -avd test -no-accel -no-snapshot -no-window $AUDIO -camera-back none -camera-front none -selinux permissive -qemu -m 2048 &
   - android-wait-for-emulator
+
+script:
+  - ./gradlew clean app:lint app:assembleDebug app:assembleDebugUnitTest app:assembleDebugAndroidTest
   - adb shell input keyevent 82 &
   - adb shell dumpsys window windows | grep -E 'mCurrentFocus|mFocusedApp'
   - adb shell input touchscreen swipe 16 239 304 287
   - adb shell dumpsys window windows | grep -E 'mCurrentFocus|mFocusedApp'
-
-script: ./gradlew clean app:lint jacocoTestReport app:assembleRelease
+  - ./gradlew jacocoTestReport
+  - ./gradlew app:assembleRelease
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
 after_failure:
+  - adb logcat -d
   - adb shell dumpsys window windows | grep -E 'mCurrentFocus|mFocusedApp'
   - adb shell "uiautomator dump /sdcard/view.xml; cat /sdcard/view.xml"
 


### PR DESCRIPTION
because emulator showing dialog "Process system isn't responding"

**Cause**
Slow emulator without accelerator enabled

**Solution**
Click close button on dialog before running android test 